### PR TITLE
Fixed workflows and missing header in twistSplineNode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master , main]
     tags:
       - v*
   pull_request:
-    branches: [ master ]
+    branches: [ master , main]
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Repath Artifacts
         run: |
           mkdir -p artifacts/plug-ins
-          cp "./build/${{env.BUILD_TYPE}}/TwistSpline.so" "artifacts/plug-ins"
+          cp "./build/TwistSpline.so" "artifacts/plug-ins"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Repath Artifacts
         run: |
-          mkdir artifacts/plug-ins
+          mkdir -p artifacts/plug-ins
           cp "./build/${{env.BUILD_TYPE}}/TwistSpline.so" "artifacts/plug-ins"
 
       - name: Upload Artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,8 @@ jobs:
             devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_5_Update_DEVKIT_Mac.dmg"
           - maya: "2023"
             devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_3_Update_DEVKIT_Mac.dmg"
+          - maya: "2024"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2024/Autodesk_Maya_2024_2_Update_DEVKIT_Mac.dmg"
 
     steps:
       - name: Checkout code
@@ -94,15 +96,15 @@ jobs:
       - name: Install devkit
         run: |
           curl -o devkit.dmg ${{matrix.devkit}}
-          7z x devkit.dmg
+          hdiutil attach devkit.dmg
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '10.3'
+          xcode-version: '13.4'
 
       - name: Configure CMake
         run: |
-          cmake -G Xcode -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="$PWD/devkitBase"
+          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
@@ -139,7 +141,7 @@ jobs:
       - name: Install devkit
         run: |
           curl -o devkit.dmg ${{matrix.devkit}}
-          7z x devkit.dmg
+          hdiutil attach devkit.dmg
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -147,7 +149,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="$PWD/devkitBase"
+          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE=-DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: mac-${{matrix.maya}}
+          name: mac-${{matrix.maya}}-x86_64
           path: |
             artifacts/plug-ins/TwistSpline.bundle
 
@@ -162,7 +162,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: mac-${{matrix.maya}}
+          name: mac-${{matrix.maya}}-arm64
           path: |
             artifacts/plug-ins/TwistSpline.bundle
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,19 +166,18 @@ jobs:
 
   maya-linux:
     runs-on: ubuntu-latest
-    # container: scottenglert/maya-build:${{matrix.maya}}
 
     strategy:
       fail-fast: false
 
       matrix:
        include:
-          - maya: "2022.5"
-            year: "2022"
-          - maya: "2023.3"
-            year: "2023"
-          - maya: "2024.2"
-            year: "2024"
+          - maya: "2022"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_5_Update_DEVKIT_Linux.tgz"
+          - maya: "2023"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_3_Update_DEVKIT_Linux.tgz"
+          - maya: "2024"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2024/Autodesk_Maya_2024_2_Update_DEVKIT_Linux.tgz"
 
     steps:
       - name: Checkout code
@@ -186,24 +185,26 @@ jobs:
         with:
           submodules: true
 
-      - name: Configure CMake
+      - name: Install devkit
         run: |
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/usr/autodesk/devkitBase" ..
+          curl -o devkit.tgz ${{matrix.devkit}}
+          tar xvzf devkit.tgz
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION="${{matrix.maya}}" -DMAYA_DEVKIT_BASE="$pwd/devkitBase"
 
       - name: Build
-        run: cmake --build ./build --config ${{env.BUILD_TYPE}}
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
       - name: Repath Artifacts
         run: |
-          mkdir -p artifacts/plug-ins
-          cp ./build/TwistSpline.so artifacts/plug-ins
+          mkdir artifacts/plug-ins
+          cp "./build/${{env.BUILD_TYPE}}/TwistSpline.so" "artifacts/plug-ins"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: linux-${{matrix.year}}
+          name: linux-${{matrix.maya}}
           path: |
             artifacts/plug-ins/TwistSpline.so
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,16 +14,16 @@ env:
 jobs:
   #
   # Windows
-  #   
+  #
   #       __
   #  |\__/  \
   #  |       |
   #  |    __ |
   #   \__/  \|
   #
-  #   
+  #
   maya-win:
-    runs-on: windows-2019
+    runs-on: [windows-2019 - windows-latest]
 
     strategy:
       # Without this, all containers stop if any fail
@@ -33,16 +33,12 @@ jobs:
 
       matrix:
        include:
-          - maya: "2018"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2018/Autodesk_Maya_2018_7_Update_DEVKIT_Windows.zip"
-          - maya: "2019"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2019/Autodesk_Maya_2019_3_Update_DEVKIT_Windows.zip"
-          - maya: "2020"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2020/Autodesk_Maya_2020_4_Update_DEVKIT_Windows.zip"
           - maya: "2022"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_3_Update_DEVKIT_Windows.zip"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_5_Update_DEVKIT_Windows.zip"
           - maya: "2023"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_DEVKIT_Windows.zip"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_3_Update_DEVKIT_Windows.zip"
+          - maya: "2024"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2024/Autodesk_Maya_2024_2_Update_DEVKIT_Windows.zip"
 
     steps:
       - name: Checkout code
@@ -75,24 +71,19 @@ jobs:
           path: |
             artifacts/plug-ins/TwistSpline.mll
 
-  maya-macos:
-    runs-on: macos-10.15
+  # Splitting mac-os into two different steps, as 2024 was made compatible with new arm architecture.
+  maya-macos-x86_64:
+    runs-on: macos-10.5
 
     strategy:
       fail-fast: false
 
       matrix:
        include:
-          - maya: "2018"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2018/Autodesk_Maya_2018_7_Update_DEVKIT_Mac.dmg"
-          - maya: "2019"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2019/Autodesk_Maya_2019_3_Update_DEVKIT_Mac.dmg"
-          - maya: "2020"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2020/Autodesk_Maya_2020_4_Update_DEVKIT_Mac.dmg"
           - maya: "2022"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_3_Update_DEVKIT_Mac.dmg"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_5_Update_DEVKIT_Mac.dmg"
           - maya: "2023"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_DEVKIT_Mac.dmg"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_3_Update_DEVKIT_Mac.dmg"
 
     steps:
       - name: Checkout code
@@ -128,6 +119,51 @@ jobs:
           path: |
             artifacts/plug-ins/TwistSpline.bundle
 
+  maya-macos-arm64:
+    runs-on: [macos-11, macos-latest]
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+       include:
+          - maya: "2024"
+            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2024/Autodesk_Maya_2024_2_Update_DEVKIT_Mac.dmg"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install devkit
+        run: |
+          curl -o devkit.dmg ${{matrix.devkit}}
+          7z x devkit.dmg
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '13.4'
+
+      - name: Configure CMake
+        run: |
+          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="$PWD/devkitBase"
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Repath Artifacts
+        run: |
+          mkdir -p artifacts/plug-ins
+          cp ./build/${{env.BUILD_TYPE}}/TwistSpline.bundle artifacts/plug-ins
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: mac-${{matrix.maya}}
+          path: |
+            artifacts/plug-ins/TwistSpline.bundle
+
   maya-linux:
     runs-on: ubuntu-latest
     container: scottenglert/maya-build:${{matrix.maya}}
@@ -137,16 +173,12 @@ jobs:
 
       matrix:
        include:
-          - maya: "2018.7"
-            year: "2018"
-          - maya: "2019.3"
-            year: "2019"
-          - maya: "2020.4"
-            year: "2020"
-          - maya: "2022.3"
+          - maya: "2022.5"
             year: "2022"
-          - maya: "2023"
+          - maya: "2023.3"
             year: "2023"
+          - maya: "2024.2"
+            year: "2024"
 
     steps:
       - name: Checkout code
@@ -189,7 +221,7 @@ jobs:
 #
   upload_release:
     name: Upload release
-    needs: [maya-win, maya-linux, maya-macos]
+    needs: [maya-win, maya-linux, maya-macos-x86_64, maya-macos-arm64]
     runs-on: ubuntu-latest
 
     # Only run on e.g. v0.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   #
   #
   maya-win:
-    runs-on: [windows-2019 - windows-latest]
+    runs-on: windows-latest
 
     strategy:
       # Without this, all containers stop if any fail
@@ -73,7 +73,7 @@ jobs:
 
   # Splitting mac-os into two different steps, as 2024 was made compatible with new arm architecture.
   maya-macos-x86_64:
-    runs-on: macos-10.5
+    runs-on: macos-latest
 
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
             artifacts/plug-ins/TwistSpline.bundle
 
   maya-macos-arm64:
-    runs-on: [macos-11, macos-latest]
+    runs-on: macos-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE=-DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
+          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,7 +191,7 @@ jobs:
           tar xvzf devkit.tgz
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION="${{matrix.maya}}" -DMAYA_DEVKIT_BASE="$pwd/devkitBase"
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION="${{matrix.maya}}" -DMAYA_DEVKIT_BASE="$PWD/devkitBase"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
 
   maya-linux:
     runs-on: ubuntu-latest
-    container: scottenglert/maya-build:${{matrix.maya}}
+    # container: scottenglert/maya-build:${{matrix.maya}}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,11 @@ name: build
 
 on:
   push:
-    branches: [ master , main]
+    branches: [ master ]
     tags:
       - v*
   pull_request:
-    branches: [ master , main]
+    branches: [ master ]
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,10 @@ jobs:
         with:
           submodules: true
 
+      - name: Install OpenGL libraries
+        run: |
+          sudo apt install libglu1-mesa-dev
+
       - name: Install devkit
         run: |
           curl -o devkit.tgz ${{matrix.devkit}}

--- a/src/twistSplineNode.cpp
+++ b/src/twistSplineNode.cpp
@@ -44,6 +44,7 @@ SOFTWARE.
 
 #include <string>
 #include <iostream>
+#include <limits>
 
 #include "twistSpline.h"
 #include "twistSplineData.h"


### PR DESCRIPTION
## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

- Added a missing `include` that was preventing from compiling the plug-in
- Reworked github workflows as anything but Linux builds where hanging or failing. Turning on `windows-latest` and `macos-latest` resolved the hanging, while on `macos` the `7z` command to extract the devkit wasn't working anymore, so the dmg is now getting mounted and the build points to the contents of that volume directly

EDIT:
Forgot to mention, also split the macos build into `x86_64` and `arm_64` to compile against new Apple chips in Maya 2024.