### PR TITLE
Some more workflow fixes and updated .mod file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
+          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,10 +115,11 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: mac-${{matrix.maya}}-x86_64
+          name: mac-${{matrix.maya}}
           path: |
             artifacts/plug-ins/TwistSpline.bundle
 
+  # This will be compiled for both x86_64 and arm64 architectures, as arm support has been added starting from Maya 2024.
   maya-macos-arm64:
     runs-on: macos-latest
 
@@ -160,7 +161,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: mac-${{matrix.maya}}-arm64
+          name: mac-${{matrix.maya}}
           path: |
             artifacts/plug-ins/TwistSpline.bundle
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,6 @@ jobs:
             devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2022/Autodesk_Maya_2022_5_Update_DEVKIT_Mac.dmg"
           - maya: "2023"
             devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2023/Autodesk_Maya_2023_3_Update_DEVKIT_Mac.dmg"
-          - maya: "2024"
-            devkit: "https://autodesk-adn-transfer.s3-us-west-2.amazonaws.com/ADN+Extranet/M%26E/Maya/devkit+2024/Autodesk_Maya_2024_2_Update_DEVKIT_Mac.dmg"
 
     steps:
       - name: Checkout code
@@ -149,7 +147,7 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
+          cmake -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DMAYA_VERSION=${{matrix.maya}} -DMAYA_DEVKIT_BASE="/Volumes/devkitBase"
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/TwistSpline.mod
+++ b/TwistSpline.mod
@@ -1,30 +1,3 @@
-+ PLATFORM:win64 MAYAVERSION:2018 TwistSpline 1.0.0 TwistSpline
-plug-ins: windows-2018
-
-+ PLATFORM:linux MAYAVERSION:2018 TwistSpline 1.0.0 TwistSpline
-plug-ins: linux-2018
-
-+ PLATFORM:mac MAYAVERSION:2018 TwistSpline 1.0.0 TwistSpline
-plug-ins: mac-2018
-
-+ PLATFORM:win64 MAYAVERSION:2019 TwistSpline 1.0.0 TwistSpline
-plug-ins: windows-2019
-
-+ PLATFORM:linux MAYAVERSION:2019 TwistSpline 1.0.0 TwistSpline
-plug-ins: linux-2019
-
-+ PLATFORM:mac MAYAVERSION:2019 TwistSpline 1.0.0 TwistSpline
-plug-ins: mac-2019
-
-+ PLATFORM:win64 MAYAVERSION:2020 TwistSpline 1.0.0 TwistSpline
-plug-ins: windows-2020
-
-+ PLATFORM:linux MAYAVERSION:2020 TwistSpline 1.0.0 TwistSpline
-plug-ins: linux-2020
-
-+ PLATFORM:mac MAYAVERSION:2020 TwistSpline 1.0.0 TwistSpline
-plug-ins: mac-2020
-
 + PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.0.0 TwistSpline
 plug-ins: windows-2022
 
@@ -42,3 +15,12 @@ plug-ins: linux-2023
 
 + PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.0.0 TwistSpline
 plug-ins: mac-2023
+
++ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.0.0 TwistSpline
+plug-ins: windows-2024
+
++ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.0.0 TwistSpline
+plug-ins: linux-2024
+
++ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.0.0 TwistSpline
+plug-ins: mac-2024


### PR DESCRIPTION
## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
Slight change to workflows to attempt compiling 2024 macos bundle for both x86_64 and arm64. Tested and working correctly on Maya 2024 on an Intel Mac, unfortunately don't have access to a new M1 mac so can't test arm64, but the fact that it worked on Intel on a .bundle compiled for both makes me think it's probably fine.

Also modified the .mod file to reflect the latest changes, but didn't increase the version myself! 