### PR TITLE
Added a "Scale Compensation" plug to both twistSpline & riderConstraint nodes.

### DIFF
--- a/TwistSpline.mod
+++ b/TwistSpline.mod
@@ -1,59 +1,59 @@
-+ PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: windows-2022
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2022 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:linux MAYAVERSION:2022 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: linux-2022
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2022 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:mac MAYAVERSION:2022 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: mac-2022
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2023 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2023 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: windows-2023
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2023 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:linux MAYAVERSION:2023 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: linux-2023
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: mac-2023
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: windows-2024
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: linux-2024
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: mac-2024
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2025 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2025 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: windows-2025
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2025 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:linux MAYAVERSION:2025 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: linux-2025
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2025 TwistSpline 1.1.1 TwistSpline
++ PLATFORM:mac MAYAVERSION:2025 TwistSpline 1.2.0 TwistSpline
 [r] icons: icons
 plug-ins: mac-2025
 [r] scripts: scripts

--- a/TwistSpline.mod
+++ b/TwistSpline.mod
@@ -1,59 +1,59 @@
-+ PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2022
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2022 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2022 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2022
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2022 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2022 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2022
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2023 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2023 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2023
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2023 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2023 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2023
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2023
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2024
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2024
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2024
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2025 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2025 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2025
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2025 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2025 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2025
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2025 TwistSpline 1.1.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2025 TwistSpline 1.1.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2025
 [r] scripts: scripts

--- a/scripts/AEriderConstraintTemplate.mel
+++ b/scripts/AEriderConstraintTemplate.mel
@@ -6,6 +6,7 @@ global proc AEriderConstraintTemplate( string $nodeName ) {
     editorTemplate -beginLayout "Global Attributes" -collapse 0;
         editorTemplate -label "Global Offset" -addControl "globalOffset";
         editorTemplate -label "Global Spread" -addControl "globalSpread";
+        editorTemplate -label "Scale Compensation" -addControl "scaleCompensation";
         editorTemplate -label "Rotate Order" -addControl "rotateOrder";
         editorTemplate -label "Use Cycle" -addControl "useCycle";
         editorTemplate -label "Normalize" -addControl "normalize";

--- a/scripts/AEtwistSplineTemplate.mel
+++ b/scripts/AEtwistSplineTemplate.mel
@@ -4,6 +4,7 @@ global proc AEtwistSplineTemplate( string $nodeName ) {
     editorTemplate -beginScrollLayout;
 
     editorTemplate -beginLayout "Spline Attributes" -collapse 0;
+        editorTemplate -label "Scale Compensation" -addControl "scaleCompensation";
         editorTemplate -label "Max Vertices" -addControl "maxVertices";
         editorTemplate -label "Vertex Data" -addControl "vertexData";
     editorTemplate -endLayout;

--- a/scripts/AEtwistTangentTemplate.mel
+++ b/scripts/AEtwistTangentTemplate.mel
@@ -1,0 +1,28 @@
+// Attribute Editor Template for Blur Studio's 'Twist Tangent' plugin.
+
+global proc AEtwistTangentTemplate( string $nodeName ) {
+    editorTemplate -beginScrollLayout;
+
+    editorTemplate -beginLayout "Input Attributes" -collapse 0;
+        editorTemplate -label "In Linear Target" -addControl "inLinearTarget";
+        editorTemplate -label "Auto" -addControl "auto";
+        editorTemplate -label "Smooth" -addControl "smooth";
+        editorTemplate -label "Weight" -addControl "weight";
+        editorTemplate -label "Backpoint" -addControl "backpoint";
+        editorTemplate -label "Endpoint" -addControl "endpoint";
+    editorTemplate -endLayout;
+
+    editorTemplate -beginLayout "Output Attributes" -collapse 0;
+        editorTemplate -label "Out" -addControl "out";
+        editorTemplate -label "Smooth Tan" -addControl "smoothTan";
+        editorTemplate -label "Out Linear Target" -addControl "outLinearTarget";
+        editorTemplate -label "Out Twist Up" -addControl "outTwistUp";
+        editorTemplate -label "Out Twist Mat" -addControl "outTwistMat";
+    editorTemplate -endLayout;
+
+    // Base class attributes
+    AEdependNodeTemplate $nodeName;
+
+    editorTemplate -addExtraControls;
+    editorTemplate -endScrollLayout;
+}

--- a/scripts/twistSplineBuilder.py
+++ b/scripts/twistSplineBuilder.py
@@ -392,7 +392,7 @@ def connectTwistSplineTangents(cvs, twBfrs, oTans, iTans, aoTans, aiTans, closed
 
 		createTwistSetup(pre, cur, post, buf, isFirst=isFirst, isLast=isLast)
 
-def buildTwistSpline(pfx, cvs, aoTans, aiTans, tws, maxParam, closed=False):
+def buildTwistSpline(pfx, cvs, aoTans, aiTans, tws, maxParam, master, closed=False):
 	""" Given all the controller objects, build a twist spline
 
 	Arguments:
@@ -445,6 +445,9 @@ def buildTwistSpline(pfx, cvs, aoTans, aiTans, tws, maxParam, closed=False):
 	cmds.setAttr("{}.Pin".format(cvs[0]), 1.0)
 	cmds.setAttr("{}.UseTwist".format(tws[0]), 1.0)
 
+	# Connect the scaleCompensation parameter
+	cmds.connectAttr("{}.scaleX".format(master), "{}.scaleCompensation".format(spline))
+
 	return splineTfm, spline
 
 def buildRiders(pfx, spline, master, numJoints, closed=False):
@@ -478,6 +481,8 @@ def buildRiders(pfx, spline, master, numJoints, closed=False):
 	cnst = cmds.createNode("riderConstraint")
 	cmds.connectAttr("{}.Offset".format(master), "{}.globalOffset".format(cnst))
 	cmds.connectAttr("{}.Stretch".format(master), "{}.globalSpread".format(cnst))
+	# Connect the scaleCompensation from the spline's twin attribute
+	cmds.connectAttr("{}.scaleCompensation".format(spline), "{}.scaleCompensation".format(cnst))
 	if closed:
 		cmds.setAttr("{}.useCycle".format(cnst), 1)
 
@@ -531,7 +536,7 @@ def makeTwistSpline(pfx, numCVs, numJoints=10, maxParam=None, spread=1.0, closed
 
 	cvs, cvBfrs, oTans, iTans, aoTans, aiTans, tws, twBfrs, master = mkTwistSplineControllers(pfx, numCVs, spread, closed=closed)
 	connectTwistSplineTangents(cvs, twBfrs, oTans, iTans, aoTans, aiTans, closed=closed)
-	splineTfm, splineShape = buildTwistSpline(pfx, cvs, aoTans, aiTans, tws, maxParam, closed=closed)
+	splineTfm, splineShape = buildTwistSpline(pfx, cvs, aoTans, aiTans, tws, maxParam, master, closed=closed)
 
 	jPars, joints, group, cnst = None, None, None, None
 	if numJoints > 0:

--- a/src/pluginMain.cpp
+++ b/src/pluginMain.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 
 MStatus initializePlugin( MObject obj ) {
 	MStatus   status;
-	MFnPlugin plugin( obj, "BlurStudio", "1.1.0", "Any");
+	MFnPlugin plugin( obj, "BlurStudio", "1.1.1", "Any");
 
 	status = plugin.registerData("twistSplineData", TwistSplineData::id, TwistSplineData::creator);
 	if (!status) {

--- a/src/pluginMain.cpp
+++ b/src/pluginMain.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 
 MStatus initializePlugin( MObject obj ) {
 	MStatus   status;
-	MFnPlugin plugin( obj, "BlurStudio", "1.1.1", "Any");
+	MFnPlugin plugin( obj, "BlurStudio", "1.2.0", "Any");
 
 	status = plugin.registerData("twistSplineData", TwistSplineData::id, TwistSplineData::creator);
 	if (!status) {

--- a/src/riderConstraint.cpp
+++ b/src/riderConstraint.cpp
@@ -144,9 +144,9 @@ MStatus riderConstraint::initialize() {
 	CHECKSTAT("aGlobalSpread");
 
 	aScaleCompensation = nAttr.create("scaleCompensation", "sclcmp", MFnNumericData::kDouble, 1.0, &status);
-	CHECKSTAT("aGlobalScale");
+	CHECKSTAT("aScaleCompensation");
 	status = addAttribute(aScaleCompensation);
-	CHECKSTAT("aGlobalScale");
+	CHECKSTAT("aScaleCompensation");
 
 	aUseCycle = nAttr.create("useCycle", "uc", MFnNumericData::kBoolean, false, &status);
 	CHECKSTAT("aUseCycle");

--- a/src/riderConstraint.cpp
+++ b/src/riderConstraint.cpp
@@ -513,7 +513,7 @@ MStatus riderConstraint::compute(const MPlug& plug, MDataBlock& data) {
 		double doNorm = normalizeH.asDouble();
 		double scaleComp = gScaleH.asDouble();
 		double normVal = normValueH.asDouble() * scaleComp;
-		double gOffset = gOffsetH.asDouble();
+		double gOffset = gOffsetH.asDouble() * scaleComp;
 		double gSpread = gSpreadH.asDouble() * scaleComp;
 		bool useCycle = useCycleH.asBool();
 

--- a/src/riderConstraint.h
+++ b/src/riderConstraint.h
@@ -41,6 +41,7 @@ public:
 	static MObject aRotateOrder;
 	static MObject aGlobalOffset;
 	static MObject aGlobalSpread;
+	static MObject aScaleCompensation;
 	static MObject aUseCycle;
 	static MObject aNormalize;
 	static MObject aNormValue;

--- a/src/twistSplineNode.cpp
+++ b/src/twistSplineNode.cpp
@@ -180,6 +180,7 @@ MStatus TwistSplineNode::initialize() {
 	attributeAffects(aUseOrient, aOutputSpline);
 	attributeAffects(aMaxVertices, aOutputSpline);
 
+	attributeAffects(aScaleCompensation, aNurbsData);
 	attributeAffects(aInTangent, aNurbsData);
 	attributeAffects(aControlVertex, aNurbsData);
 	attributeAffects(aOutTangent, aNurbsData);
@@ -196,6 +197,7 @@ MStatus TwistSplineNode::initialize() {
 	attributeAffects(aMaxVertices, aSplineLength);
 
 	// Geometry changing
+	attributeAffects(aScaleCompensation, aGeometryChanging);
 	attributeAffects(aInTangent, aGeometryChanging);
 	attributeAffects(aControlVertex, aGeometryChanging);
 	attributeAffects(aOutTangent, aGeometryChanging);
@@ -266,9 +268,15 @@ void TwistSplineNode::getDebugDraw(bool &oDraw, double &oScale) const {
 			drawPlug.getValue(oDraw);
 		}
 
+		MPlug scaleCompPlug(mobj, aScaleCompensation);
+		double scaleComp = 1.0;
+		if (!scaleCompPlug.isNull())
+			scaleCompPlug.getValue(scaleComp);
+
 		MPlug scalePlug(mobj, aDebugScale);
 		if (!scalePlug.isNull()) {
 			scalePlug.getValue(oScale);
+			oScale *= scaleComp;
 		}
 	}
 
@@ -502,7 +510,8 @@ MStatus TwistSplineNode::setDependentsDirty(const MPlug& plug,
 		if (plug == aInTangent || plug == aOutTangent ||
 			plug == aControlVertex || plug == aMaxVertices ||
 			plug == aParamValue || plug == aParamWeight ||
-			plug == aTwistValue || plug == aTwistWeight || plug == aUseOrient) {
+			plug == aTwistValue || plug == aTwistWeight || plug == aUseOrient ||
+			plug == aScaleCompensation) {
 			MObject thisNode = thisMObject();
 			MPlug outputSplinePlug(thisNode, aOutputSpline);
 			MPlug nurbsDataPlug(thisNode, aNurbsData);

--- a/src/twistSplineNode.h
+++ b/src/twistSplineNode.h
@@ -99,6 +99,7 @@ public:
 		static MObject aUseOrient;
 
 	static MObject aGeometryChanging;
+	static MObject aScaleCompensation;
 	static MObject aSplineDisplay;
 	static MObject aDebugDisplay;
 	static MObject aDebugScale;

--- a/src/twistTangentNode.cpp
+++ b/src/twistTangentNode.cpp
@@ -100,10 +100,13 @@ MStatus TwistTangentNode::initialize() {
 	// The final output point relative to the parentInverseMatrix
 	// This is the data that will eventually get plugged into the spline
 	aOutX = uAttr.create("outX", "ox", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aOutX")
 	aOutY = uAttr.create("outY", "oy", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aOutY")
 	aOutZ = uAttr.create("outZ", "oz", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aOutZ")
 	aOut = nAttr.create("out", "out", aOutX, aOutY, aOutZ, &status);
 	CHECKSTAT("aOut")
@@ -111,10 +114,13 @@ MStatus TwistTangentNode::initialize() {
 
 	// The position of the smooth tangent relative to the parentInverseMatrix
 	aSmoothTanX = uAttr.create("smoothTanX", "stx", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aSmoothTanX")
 	aSmoothTanY = uAttr.create("smoothTanY", "sty", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aSmoothTanY")
 	aSmoothTanZ = uAttr.create("smoothTanZ", "stz", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aSmoothTanZ")
 	aSmoothTan = nAttr.create("smoothTan", "st", aSmoothTanX, aSmoothTanY, aSmoothTanZ, &status);
 	CHECKSTAT("aSmoothTan")
@@ -123,10 +129,13 @@ MStatus TwistTangentNode::initialize() {
 	// The target that the adjacent tangent will point at when it's in auto-linear mode
 	// relative to the parentInverseMatrix
 	aOutLinearTargetX = uAttr.create("outLinearTargetX", "ltx", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aLinearTargetX")
 	aOutLinearTargetY = uAttr.create("outLinearTargetY", "lty", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aLinearTargetY")
 	aOutLinearTargetZ = uAttr.create("outLinearTargetZ", "ltz", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aLinearTargetZ")
 	aOutLinearTarget = nAttr.create("outLinearTarget", "lt", aOutLinearTargetX, aOutLinearTargetY, aOutLinearTargetZ, &status);
 	CHECKSTAT("aLinearTarget")
@@ -134,10 +143,13 @@ MStatus TwistTangentNode::initialize() {
 
 	// The up-vector based off the prev and next vertices, relative to the parentInverseMatrix
 	aOutTwistUpX = uAttr.create("outTwistUpX", "otx", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aTwistUpX")
 	aOutTwistUpY = uAttr.create("outTwistUpY", "oty", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aTwistUpY")
 	aOutTwistUpZ = uAttr.create("outTwistUpZ", "otz", MFnUnitAttribute::kDistance, 0.0, &status);
+	uAttr.setWritable(false);
 	CHECKSTAT("aTwistUpZ")
 	aOutTwistUp = nAttr.create("outTwistUp", "ot", aOutTwistUpX, aOutTwistUpY, aOutTwistUpZ, &status);
 	CHECKSTAT("aTwistUp")
@@ -146,6 +158,7 @@ MStatus TwistTangentNode::initialize() {
 	// The up-vector matrix based off the prev and next vertices relative to the parentInverseMatrix
 	aOutTwistMat = mAttr.create("outTwistMat", "otm");
 	mAttr.setDefault(MMatrix::identity);
+	mAttr.setWritable(false);
 	addAttribute(aOutTwistMat);
 
 	//----------------- Matrices -----------------
@@ -470,3 +483,7 @@ MStatus TwistTangentNode::compute(const MPlug& plug, MDataBlock& data) {
 	return MS::kSuccess;
 }
 
+void TwistTangentNode::postConstructor() {
+	MFnDependencyNode nodeFn(thisMObject());
+	nodeFn.setIcon("twistTangent.png");
+}

--- a/src/twistTangentNode.h
+++ b/src/twistTangentNode.h
@@ -24,19 +24,21 @@ SOFTWARE.
 
 #pragma once
 
+#include <maya/MFnDependencyNode.h>
 #include <maya/MStatus.h>
 #include <maya/MObject.h>
 #include <maya/MPxNode.h>
-#include <maya/MTypeId.h> 
- 
+#include <maya/MTypeId.h>
+
 class TwistTangentNode : public MPxNode {
 public:
 	TwistTangentNode();
-	virtual	~TwistTangentNode(); 
+	virtual	~TwistTangentNode();
 
 	virtual	MStatus	compute( const MPlug& plug, MDataBlock& data );
 	static	void*	creator();
 	static	MStatus	initialize();
+	void postConstructor() override;
 
 public:
 	// outputs


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I have added documentation regarding my changes where necessary

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
Here I am just making sure the rig is scalable by providing a couple of extra "Scale Compensation" attributes to the `twistSpline` and `riderConstraint` nodes. I figured I could give it a try by replicating what I'm currently doing in the rigging tools at work to get the rig to scale correctly, which are compensating the spline parameters and the rider constraint `globalSpread` and `normalizedValue`. I haven't found any other way to make it work, so if there's any please let me know!
But if not, I think this could cut down quite a few unnecessary nodes in a rig, as each spline param would otherwise need a separate multiply node for the param to scale up correctly.

I also took the chance to update the attribute templates with the new attribute, along with including the previously missing `twistTangent` template and the outliner's icon assignment. I hope you don't mind me locking some output parameters on the twistTangent, just as a visual distinction from the input ones; if you prefer to have them editable all the time I can roll back that change!

Cheers!

EDIT: for the `riderConstraint`, this will work for both normalized and param-based modes!