### PR TITLE
Fix the twist mult, the twist matrix scale, and the close plug

### DIFF
--- a/TwistSpline.mod
+++ b/TwistSpline.mod
@@ -1,59 +1,59 @@
-+ PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2022 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2022
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2022 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2022 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2022
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2022 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2022 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2022
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2023 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2023 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2023
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2023 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2023 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2023
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2023 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2023
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2024 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2024
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2024 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2024
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2024 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2024
 [r] scripts: scripts
 
-+ PLATFORM:win64 MAYAVERSION:2025 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:win64 MAYAVERSION:2025 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: windows-2025
 [r] scripts: scripts
 
-+ PLATFORM:linux MAYAVERSION:2025 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:linux MAYAVERSION:2025 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: linux-2025
 [r] scripts: scripts
 
-+ PLATFORM:mac MAYAVERSION:2025 TwistSpline 1.2.0 TwistSpline
++ PLATFORM:mac MAYAVERSION:2025 TwistSpline 1.2.1 TwistSpline
 [r] icons: icons
 plug-ins: mac-2025
 [r] scripts: scripts

--- a/scripts/twistSplineBuilder.py
+++ b/scripts/twistSplineBuilder.py
@@ -811,11 +811,13 @@ def makeTwistSpline(
         connectTwistSplineMultiTangents(
             cvs, twBfrs, oCtrls, iCtrls, oBfrs, iBfrs, oRests, iRests, closed=closed
         )
+        twistMul = 1.0
     else:
         connectTwistSplineTangents(cvs, twBfrs, oCtrls, iCtrls, oBfrs, iBfrs, closed=closed)
+        twistMul = -1.0
 
     splineTfm, splineShape = buildTwistSpline(
-        pfx, cvs, oCtrls, iCtrls, tws, maxParam, master, closed=closed, twistMul=-1.0
+        pfx, cvs, oCtrls, iCtrls, tws, maxParam, master, closed=closed, twistMul=twistMul
     )
 
     jPars, joints, group, cnst = None, None, None, None

--- a/src/pluginMain.cpp
+++ b/src/pluginMain.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 
 MStatus initializePlugin( MObject obj ) {
 	MStatus   status;
-	MFnPlugin plugin( obj, "BlurStudio", "1.2.0", "Any");
+	MFnPlugin plugin( obj, "BlurStudio", "1.2.1", "Any");
 
 	status = plugin.registerData("twistSplineData", TwistSplineData::id, TwistSplineData::creator);
 	if (!status) {

--- a/src/twistMultiTangentNode.cpp
+++ b/src/twistMultiTangentNode.cpp
@@ -37,6 +37,8 @@ SOFTWARE.
 #include <maya/MFnUnitAttribute.h>
 #include <maya/MGlobal.h>
 #include <maya/MMatrix.h>
+#include <maya/MTransformationMatrix.h>
+#include <maya/MQuaternion.h>
 #include <maya/MPlug.h>
 #include <maya/MTypes.h>
 #include <maya/MVector.h>
@@ -209,7 +211,6 @@ MStatus TwistMultiTangentNode::initialize()
     aClosed = num_attr.create("closed", "cl", MFnNumericData::kBoolean, false, &status);
     num_attr.setKeyable(true);
     num_attr.setStorable(true);
-    num_attr.setMin(2);
     addAttribute(aClosed);
 
     aInTanX =
@@ -650,7 +651,9 @@ MStatus TwistMultiTangentNode::compute(const MPlug &plug, MDataBlock &data)
         outTanLenHandle.setDouble(cur.outTan.doneTan.length());
 
         auto outMatHandle = outHandle.child(aOutTwistMat);
-        outMatHandle.setMMatrix(cur.smoothMat * cur.piTwist);
+
+        MTransformationMatrix oriMat = cur.smoothMat * cur.piTwist;
+        outMatHandle.setMMatrix(oriMat.rotation().asMatrix());
 
         auto outTwistHandle = outHandle.child(aOutTwistUp);
         outTwistHandle.set3Double(cur.tfmMat(1, 0), cur.tfmMat(1, 1), cur.tfmMat(1, 2));


### PR DESCRIPTION
Added the twist mult into the builder (that I forgot)
Have the twist matrix inherit the scale from its parent.
Get rid of the min-value for the `closed` boolean plug.

Should fix these: https://github.com/blurstudio/TwistSpline/issues/31 https://github.com/blurstudio/TwistSpline/issues/32