### PR TITLE
Added option to swap axes orientation on rider constraint

### DIFF
--- a/scripts/AEriderConstraintTemplate.mel
+++ b/scripts/AEriderConstraintTemplate.mel
@@ -4,10 +4,14 @@ global proc AEriderConstraintTemplate( string $nodeName ) {
     editorTemplate -beginScrollLayout;
 
     editorTemplate -beginLayout "Global Attributes" -collapse 0;
+        editorTemplate -label "Inverse Forward" -addControl "inverseForward";
+        editorTemplate -label "Inverse Up" -addControl "inverseUp";
+        editorTemplate -label "Forward Axis" -addControl "forwardAxis";
+        editorTemplate -label "Up Axis" -addControl "upAxis";
+        editorTemplate -label "Rotate Order" -addControl "rotateOrder";
         editorTemplate -label "Global Offset" -addControl "globalOffset";
         editorTemplate -label "Global Spread" -addControl "globalSpread";
         editorTemplate -label "Scale Compensation" -addControl "scaleCompensation";
-        editorTemplate -label "Rotate Order" -addControl "rotateOrder";
         editorTemplate -label "Use Cycle" -addControl "useCycle";
         editorTemplate -label "Normalize" -addControl "normalize";
         editorTemplate -label "Norm Value" -addControl "normValue";

--- a/scripts/twistSplineBuilder.py
+++ b/scripts/twistSplineBuilder.py
@@ -761,6 +761,7 @@ def buildRiders(pfx, spline, master, numJoints, closed=False):
         )
         cmds.connectAttr(f"{cnst}.outputs[{i}].rotate", f"{jPars[i]}.rotate")
         cmds.connectAttr(f"{cnst}.outputs[{i}].scale", f"{jPars[i]}.scale")
+        cmds.connectAttr(f"{cnst}.rotateOrder", f"{jPars[i]}.rotateOrder")
 
     return jPars, joints, jointsGrp, cnst
 

--- a/src/riderConstraint.h
+++ b/src/riderConstraint.h
@@ -23,8 +23,10 @@ SOFTWARE.
 */
 
 #pragma once
+#include <maya/MGlobal.h>
 #include <maya/MPxNode.h>
 #include <maya/MFnDependencyNode.h>
+#include "math.h"
 
 class riderConstraint : public MPxNode {
 public:
@@ -38,6 +40,10 @@ public:
 
 public:
 	// inputs
+	static MObject aForwardAxis;
+	static MObject aForwardAxisInverse;
+	static MObject aUpAxis;
+	static MObject aUpAxisInverse;
 	static MObject aRotateOrder;
 	static MObject aGlobalOffset;
 	static MObject aGlobalSpread;
@@ -69,7 +75,7 @@ public:
 
 	// output
 	static MObject aOutputs;
-		static MObject aOutMat;
+		static MObject aOutputMatrix;
 		static MObject aTranslate;
 		static MObject aTranslateX;
 		static MObject aTranslateY;
@@ -84,5 +90,12 @@ public:
 		static MObject aScaleZ;
 
 	static MTypeId id;
-};
 
+	static MTransformationMatrix recomputeRotationMatrix(
+		const MMatrix& matrix,
+		const short& forwardAxisIdx,
+		const short& upAxisIdx,
+		const bool& inverseForward,
+		const bool& inverseUp,
+		const MTransformationMatrix::RotationOrder& order);
+};


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I have added documentation regarding my changes where necessary

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
Added the ability to swap axes orientations on the rider constraint node, similarly to what Maya's native motion path node can do. The AE Template has also been updated to organize the new attributes.

I also took the chance to add a native outputMatrix port in the output array, which I think was supposed to be there from the beginning as there was an `aOutMat` MObject declared that was never implemented.
Since I was dealing with `MTransformationMatrix` I changed the reorder rotations logic to use that class instead of MEulerRotations, so the decompose is not necessary anymore.

Here's a video showing the changes: [Twist Spline - Rider Constraint Axes Orientation Feature](https://youtu.be/lEnYvVfW1wg?feature=shared)